### PR TITLE
[codex] Add ranking score adjustments

### DIFF
--- a/prisma/migrations/20260423000000_enable_rls_public/migration.sql
+++ b/prisma/migrations/20260423000000_enable_rls_public/migration.sql
@@ -1,0 +1,31 @@
+-- Lock public.* tables from Supabase PostgREST (anon/authenticated roles).
+-- Prisma connects as `postgres` which bypasses RLS, so app behavior is unchanged.
+ALTER TABLE "public"."admins"         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."albums"         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."artists"        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."bars"           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."feature_items"  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."features"       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."news_entries"   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."owners"         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."records"        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."tracks"         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."likes"          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."labels"         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."sync_jobs"      ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'anon') THEN
+    REVOKE ALL ON ALL TABLES    IN SCHEMA "public" FROM anon;
+    REVOKE ALL ON ALL SEQUENCES IN SCHEMA "public" FROM anon;
+    REVOKE ALL ON ALL FUNCTIONS IN SCHEMA "public" FROM anon;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'authenticated') THEN
+    REVOKE ALL ON ALL TABLES    IN SCHEMA "public" FROM authenticated;
+    REVOKE ALL ON ALL SEQUENCES IN SCHEMA "public" FROM authenticated;
+    REVOKE ALL ON ALL FUNCTIONS IN SCHEMA "public" FROM authenticated;
+  END IF;
+END
+$$;

--- a/prisma/migrations/20260506000000_add_ranking_adjustments/migration.sql
+++ b/prisma/migrations/20260506000000_add_ranking_adjustments/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "ranking_adjustments" (
+    "id" BIGSERIAL NOT NULL,
+    "record_id" BIGINT,
+    "track_id" BIGINT,
+    "score_delta" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ranking_adjustments_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "ranking_adjustments_single_target_check" CHECK (
+        ("record_id" IS NOT NULL AND "track_id" IS NULL) OR
+        ("record_id" IS NULL AND "track_id" IS NOT NULL)
+    )
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ranking_adjustments_record_id_key" ON "ranking_adjustments"("record_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ranking_adjustments_track_id_key" ON "ranking_adjustments"("track_id");
+
+-- AddForeignKey
+ALTER TABLE "ranking_adjustments" ADD CONSTRAINT "ranking_adjustments_record_id_fkey" FOREIGN KEY ("record_id") REFERENCES "records"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ranking_adjustments" ADD CONSTRAINT "ranking_adjustments_track_id_fkey" FOREIGN KEY ("track_id") REFERENCES "tracks"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260506110500_lock_ranking_adjustments/migration.sql
+++ b/prisma/migrations/20260506110500_lock_ranking_adjustments/migration.sql
@@ -1,0 +1,17 @@
+-- Lock ranking_adjustments from Supabase PostgREST (anon/authenticated roles).
+-- Prisma connects as `postgres` which bypasses RLS, so app behavior is unchanged.
+ALTER TABLE "public"."ranking_adjustments" ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'anon') THEN
+    REVOKE ALL ON TABLE "public"."ranking_adjustments" FROM anon;
+    REVOKE ALL ON SEQUENCE "public"."ranking_adjustments_id_seq" FROM anon;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'authenticated') THEN
+    REVOKE ALL ON TABLE "public"."ranking_adjustments" FROM authenticated;
+    REVOKE ALL ON SEQUENCE "public"."ranking_adjustments_id_seq" FROM authenticated;
+  END IF;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,6 +134,7 @@ model Record {
   artist Artist? @relation(fields: [artistId], references: [id], onDelete: Cascade)
   owner  Owner?  @relation(fields: [ownerId], references: [id])
   likes  Like[]
+  rankingAdjustment RankingAdjustment?
 
   @@unique([bar, location, number])
   @@map("records")
@@ -154,6 +155,7 @@ model Track {
   artist Artist? @relation(fields: [artistId], references: [id], onDelete: Cascade)
   album  Album?  @relation(fields: [albumId], references: [id], onDelete: Cascade)
   likes  Like[]
+  rankingAdjustment RankingAdjustment?
 
   @@map("tracks")
 }
@@ -174,6 +176,20 @@ model Like {
   @@index([recordId])
   @@index([trackId])
   @@map("likes")
+}
+
+model RankingAdjustment {
+  id         BigInt   @id @default(autoincrement())
+  recordId   BigInt?  @unique @map("record_id")
+  trackId    BigInt?  @unique @map("track_id")
+  scoreDelta Int      @default(0) @map("score_delta")
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  record Record? @relation(fields: [recordId], references: [id], onDelete: Cascade)
+  track  Track?  @relation(fields: [trackId], references: [id], onDelete: Cascade)
+
+  @@map("ranking_adjustments")
 }
 
 model Label {

--- a/src/app/[bar]/admin/records/[id]/edit/page.tsx
+++ b/src/app/[bar]/admin/records/[id]/edit/page.tsx
@@ -16,6 +16,7 @@ export default function EditRecordPage() {
   const [name, setName] = useState("");
   const [phoneticName, setPhoneticName] = useState("");
   const [furigana, setFurigana] = useState("");
+  const [scoreDelta, setScoreDelta] = useState("0");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -30,6 +31,7 @@ export default function EditRecordPage() {
         setName(data.name ?? "");
         setPhoneticName(data.phoneticName ?? "");
         setFurigana(data.furigana ?? "");
+        setScoreDelta(String(data.rankingAdjustment?.scoreDelta ?? 0));
       })
       .catch(() => setError("取得に失敗しました"))
       .finally(() => setLoading(false));
@@ -37,6 +39,12 @@ export default function EditRecordPage() {
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
+    const parsedScoreDelta = Number(scoreDelta);
+    if (!Number.isInteger(parsedScoreDelta)) {
+      setError("ランキング補正は整数で入力してください");
+      return;
+    }
+
     setSaving(true);
     setError(null);
 
@@ -50,6 +58,18 @@ export default function EditRecordPage() {
         }),
       });
       if (!res.ok) throw new Error("Failed to save");
+
+      const adjustmentRes = await fetch("/api/ranking-adjustments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          itemType: "Record",
+          itemId: id,
+          scoreDelta: parsedScoreDelta,
+        }),
+      });
+      if (!adjustmentRes.ok) throw new Error("Failed to save ranking adjustment");
+
       router.push(`/${bar}/admin/records`);
     } catch {
       setError("保存に失敗しました");
@@ -98,6 +118,16 @@ export default function EditRecordPage() {
         <div>
           <label className="block text-sm font-medium text-zinc-300">ふりがな</label>
           <input type="text" value={furigana} onChange={(e) => setFurigana(e.target.value)} className={inputClass} />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-zinc-300">ランキング補正</label>
+          <input
+            type="number"
+            step="1"
+            value={scoreDelta}
+            onChange={(e) => setScoreDelta(e.target.value)}
+            className={inputClass}
+          />
         </div>
         <button
           type="submit"

--- a/src/app/[bar]/admin/records/page.tsx
+++ b/src/app/[bar]/admin/records/page.tsx
@@ -3,6 +3,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
+import {
+  parseAdminTableSort,
+  SortableHeaderButton,
+  type AdminTableSort,
+} from "@/components/admin/SortableHeaderButton";
 
 const PAGE_SIZE = 50;
 
@@ -13,6 +18,8 @@ interface Record {
   number: string | null;
   artist: { id: string; name: string | null } | null;
   owner: { id: string; name: string | null } | null;
+  _count?: { likes: number };
+  rankingAdjustment?: { scoreDelta: number } | null;
 }
 
 export default function AdminRecordsPage() {
@@ -21,6 +28,7 @@ export default function AdminRecordsPage() {
   const router = useRouter();
   const bar = params.bar as string;
   const artistId = searchParams.get("artistId");
+  const sort = parseAdminTableSort(searchParams.get("sort"));
 
   const [records, setRecords] = useState<Record[]>([]);
   const [total, setTotal] = useState(0);
@@ -31,12 +39,13 @@ export default function AdminRecordsPage() {
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
-  const search = useCallback(async (q: string, p: number) => {
+  const search = useCallback(async (q: string, p: number, sortMode: AdminTableSort) => {
     setLoading(true);
     try {
       const params = new URLSearchParams({ page: String(p), limit: String(PAGE_SIZE), bar });
       if (q.trim()) params.set("query", q.trim());
       if (artistId) params.set("artistId", artistId);
+      if (sortMode !== "default") params.set("sort", sortMode);
       const res = await fetch(`/api/records?${params}`);
       if (!res.ok) throw new Error("Failed to fetch");
       const json = await res.json();
@@ -50,16 +59,28 @@ export default function AdminRecordsPage() {
   }, [bar, artistId]);
 
   useEffect(() => {
-    search(query, page);
-  }, [search, page]);
-
-  useEffect(() => {
     const timer = setTimeout(() => {
-      setPage(1);
-      search(query, 1);
+      search(query, page, sort);
     }, 300);
     return () => clearTimeout(timer);
-  }, [query, search]);
+  }, [query, page, sort, search]);
+
+  function handleQueryChange(value: string) {
+    setQuery(value);
+    setPage(1);
+  }
+
+  function handleSort(nextSort: AdminTableSort) {
+    const nextParams = new URLSearchParams(searchParams.toString());
+    if (nextSort === "default" || sort === nextSort) {
+      nextParams.delete("sort");
+    } else {
+      nextParams.set("sort", nextSort);
+    }
+    setPage(1);
+    const queryString = nextParams.toString();
+    router.push(queryString ? `/${bar}/admin/records?${queryString}` : `/${bar}/admin/records`);
+  }
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-8">
@@ -98,7 +119,7 @@ export default function AdminRecordsPage() {
         <input
           type="text"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => handleQueryChange(e.target.value)}
           placeholder="レコード名・アーティスト名で検索..."
           className="block w-full rounded-md border border-zinc-600 bg-zinc-800 px-3 py-2 text-white placeholder-zinc-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         />
@@ -134,9 +155,33 @@ export default function AdminRecordsPage() {
             <thead>
               <tr className="border-b border-zinc-700 text-zinc-400">
                 <th className="py-2 font-medium">レコード名</th>
-                <th className="py-2 font-medium">アーティスト</th>
+                <th className="py-2">
+                  <SortableHeaderButton
+                    label="アーティスト"
+                    active={sort === "default"}
+                    direction="asc"
+                    title="アーティスト名で昇順に並べ替え"
+                    onClick={() => handleSort("default")}
+                  />
+                </th>
                 <th className="py-2 font-medium">場所</th>
                 <th className="py-2 font-medium">番号</th>
+                <th className="w-20 py-2 text-right">
+                  <SortableHeaderButton
+                    label="いいね"
+                    active={sort === "likes_desc"}
+                    title="いいね数で降順に並べ替え"
+                    onClick={() => handleSort("likes_desc")}
+                  />
+                </th>
+                <th className="w-20 py-2 text-right">
+                  <SortableHeaderButton
+                    label="補正"
+                    active={sort === "adjusted_likes_desc"}
+                    title="補正込みのいいね数で降順に並べ替え"
+                    onClick={() => handleSort("adjusted_likes_desc")}
+                  />
+                </th>
                 <th className="py-2" />
               </tr>
             </thead>
@@ -151,6 +196,10 @@ export default function AdminRecordsPage() {
                   </td>
                   <td className="py-3 text-zinc-400">{record.location ?? "—"}</td>
                   <td className="py-3 text-zinc-400">{record.number ?? "—"}</td>
+                  <td className="w-20 py-3 text-right text-zinc-400">{record._count?.likes ?? 0}</td>
+                  <td className="w-20 py-3 text-right text-zinc-400">
+                    {record.rankingAdjustment?.scoreDelta ?? 0}
+                  </td>
                   <td className="py-3 text-right">
                     <button
                       onClick={() => router.push(`/${bar}/admin/records/${record.id}/edit`)}
@@ -164,7 +213,7 @@ export default function AdminRecordsPage() {
               ))}
               {records.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="py-8 text-center text-zinc-500">
+                  <td colSpan={7} className="py-8 text-center text-zinc-500">
                     レコードが見つかりません
                   </td>
                 </tr>

--- a/src/app/[bar]/admin/tracks/[id]/edit/page.tsx
+++ b/src/app/[bar]/admin/tracks/[id]/edit/page.tsx
@@ -22,6 +22,7 @@ export default function EditTrackPage() {
   const [phoneticName, setPhoneticName] = useState("");
   const [furigana, setFurigana] = useState("");
   const [number, setNumber] = useState<number | "">("");
+  const [scoreDelta, setScoreDelta] = useState("0");
   const [artistId, setArtistId] = useState("");
   const [albumId, setAlbumId] = useState("");
   const [artistQuery, setArtistQuery] = useState("");
@@ -45,6 +46,7 @@ export default function EditTrackPage() {
         setPhoneticName(data.phoneticName ?? "");
         setFurigana(data.furigana ?? "");
         setNumber(data.number ?? "");
+        setScoreDelta(String(data.rankingAdjustment?.scoreDelta ?? 0));
         if (data.artist) {
           setSelectedArtist({ id: data.artist.id, name: data.artist.name });
           setArtistId(data.artist.id);
@@ -102,6 +104,12 @@ export default function EditTrackPage() {
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
+    const parsedScoreDelta = Number(scoreDelta);
+    if (!Number.isInteger(parsedScoreDelta)) {
+      setError("ランキング補正は整数で入力してください");
+      return;
+    }
+
     setSaving(true);
     setError(null);
 
@@ -119,6 +127,18 @@ export default function EditTrackPage() {
         }),
       });
       if (!res.ok) throw new Error("Failed to save");
+
+      const adjustmentRes = await fetch("/api/ranking-adjustments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          itemType: "Hi-Res",
+          itemId: id,
+          scoreDelta: parsedScoreDelta,
+        }),
+      });
+      if (!adjustmentRes.ok) throw new Error("Failed to save ranking adjustment");
+
       router.push(`/${bar}/admin/tracks`);
     } catch {
       setError("保存に失敗しました");
@@ -174,6 +194,16 @@ export default function EditTrackPage() {
             type="number"
             value={number}
             onChange={(e) => setNumber(e.target.value === "" ? "" : parseInt(e.target.value))}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-zinc-300">ランキング補正</label>
+          <input
+            type="number"
+            step="1"
+            value={scoreDelta}
+            onChange={(e) => setScoreDelta(e.target.value)}
             className={inputClass}
           />
         </div>

--- a/src/app/[bar]/admin/tracks/page.tsx
+++ b/src/app/[bar]/admin/tracks/page.tsx
@@ -3,6 +3,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
+import {
+  parseAdminTableSort,
+  SortableHeaderButton,
+  type AdminTableSort,
+} from "@/components/admin/SortableHeaderButton";
 
 const PAGE_SIZE = 50;
 
@@ -12,6 +17,8 @@ interface Track {
   number: number | null;
   artist: { id: string; name: string | null } | null;
   album: { id: string; name: string | null } | null;
+  _count?: { likes: number };
+  rankingAdjustment?: { scoreDelta: number } | null;
 }
 
 export default function AdminTracksPage() {
@@ -21,6 +28,7 @@ export default function AdminTracksPage() {
   const bar = params.bar as string;
   const artistId = searchParams.get("artistId");
   const albumId = searchParams.get("albumId");
+  const sort = parseAdminTableSort(searchParams.get("sort"));
 
   const [tracks, setTracks] = useState<Track[]>([]);
   const [total, setTotal] = useState(0);
@@ -31,13 +39,14 @@ export default function AdminTracksPage() {
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
-  const search = useCallback(async (q: string, p: number) => {
+  const search = useCallback(async (q: string, p: number, sortMode: AdminTableSort) => {
     setLoading(true);
     try {
       const params = new URLSearchParams({ page: String(p), limit: String(PAGE_SIZE), bar });
       if (q.trim()) params.set("query", q.trim());
       if (artistId) params.set("artistId", artistId);
       if (albumId) params.set("albumId", albumId);
+      if (sortMode !== "default") params.set("sort", sortMode);
       const res = await fetch(`/api/tracks?${params}`);
       if (!res.ok) throw new Error("Failed to fetch");
       const json = await res.json();
@@ -51,23 +60,35 @@ export default function AdminTracksPage() {
   }, [bar, artistId, albumId]);
 
   useEffect(() => {
-    search(query, page);
-  }, [search, page]);
-
-  useEffect(() => {
     const timer = setTimeout(() => {
-      setPage(1);
-      search(query, 1);
+      search(query, page, sort);
     }, 300);
     return () => clearTimeout(timer);
-  }, [query, search]);
+  }, [query, page, sort, search]);
+
+  function handleQueryChange(value: string) {
+    setQuery(value);
+    setPage(1);
+  }
+
+  function handleSort(nextSort: AdminTableSort) {
+    const nextParams = new URLSearchParams(searchParams.toString());
+    if (nextSort === "default" || sort === nextSort) {
+      nextParams.delete("sort");
+    } else {
+      nextParams.set("sort", nextSort);
+    }
+    setPage(1);
+    const queryString = nextParams.toString();
+    router.push(queryString ? `/${bar}/admin/tracks?${queryString}` : `/${bar}/admin/tracks`);
+  }
 
   async function handleDelete(id: string, name: string) {
     if (!confirm(`「${name}」を削除しますか？`)) return;
     try {
       const res = await fetch(`/api/tracks/${id}`, { method: "DELETE" });
       if (!res.ok) throw new Error("Failed to delete");
-      search(query, page);
+      search(query, page, sort);
     } catch {
       setError("削除に失敗しました");
     }
@@ -127,7 +148,7 @@ export default function AdminTracksPage() {
         <input
           type="text"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => handleQueryChange(e.target.value)}
           placeholder="トラック名・アーティスト名で検索..."
           className="block w-full rounded-md border border-zinc-600 bg-zinc-800 px-3 py-2 text-white placeholder-zinc-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         />
@@ -163,9 +184,33 @@ export default function AdminTracksPage() {
             <thead>
               <tr className="border-b border-zinc-700 text-zinc-400">
                 <th className="py-2 font-medium">No.</th>
-                <th className="py-2 font-medium">トラック名</th>
+                <th className="py-2">
+                  <SortableHeaderButton
+                    label="トラック名"
+                    active={sort === "default"}
+                    direction="asc"
+                    title="トラック名で昇順に並べ替え"
+                    onClick={() => handleSort("default")}
+                  />
+                </th>
                 <th className="py-2 font-medium">アーティスト</th>
                 <th className="py-2 font-medium">アルバム</th>
+                <th className="w-20 py-2 text-right">
+                  <SortableHeaderButton
+                    label="いいね"
+                    active={sort === "likes_desc"}
+                    title="いいね数で降順に並べ替え"
+                    onClick={() => handleSort("likes_desc")}
+                  />
+                </th>
+                <th className="w-20 py-2 text-right">
+                  <SortableHeaderButton
+                    label="補正"
+                    active={sort === "adjusted_likes_desc"}
+                    title="補正込みのいいね数で降順に並べ替え"
+                    onClick={() => handleSort("adjusted_likes_desc")}
+                  />
+                </th>
                 <th className="py-2" />
               </tr>
             </thead>
@@ -183,6 +228,10 @@ export default function AdminTracksPage() {
                     {track.album ? (
                       <button onClick={() => router.push(`/${bar}/admin/albums/${track.album!.id}`)} className="hover:text-blue-400 hover:underline">{track.album.name ?? "—"}</button>
                     ) : "—"}
+                  </td>
+                  <td className="w-20 py-3 text-right text-zinc-400">{track._count?.likes ?? 0}</td>
+                  <td className="w-20 py-3 text-right text-zinc-400">
+                    {track.rankingAdjustment?.scoreDelta ?? 0}
                   </td>
                   <td className="py-3 text-right"><div className="flex items-center justify-end gap-2">
                     <button
@@ -204,7 +253,7 @@ export default function AdminTracksPage() {
               ))}
               {tracks.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="py-8 text-center text-zinc-500">
+                  <td colSpan={7} className="py-8 text-center text-zinc-500">
                     トラックが見つかりません
                   </td>
                 </tr>

--- a/src/app/[bar]/albums/[id]/tracks/page.tsx
+++ b/src/app/[bar]/albums/[id]/tracks/page.tsx
@@ -3,13 +3,14 @@ import { prisma } from "@/lib/prisma";
 import { serializeBigInt } from "@/lib/utils";
 import { RecordList } from "@/components/RecordList";
 import { getSessionId } from "@/lib/session";
+import { getAdjustedTrackLikeCounts } from "@/lib/ranking-adjustments";
 
 export default async function AlbumTracksPage({
   params,
 }: {
   params: Promise<{ bar: string; id: string }>;
 }) {
-  const { bar, id } = await params;
+  const { id } = await params;
 
   const album = await prisma.album.findUnique({
     where: { id: BigInt(id) },
@@ -38,21 +39,11 @@ export default async function AlbumTracksPage({
   const trackIds = tracks.map((t) => BigInt(t.id));
 
   // Like counts
-  const likeCounts: Record<string, number> = {};
-  if (trackIds.length > 0) {
-    const counts = await prisma.like.groupBy({
-      by: ["trackId"],
-      where: { trackId: { in: trackIds } },
-      _count: { trackId: true },
-    });
-    for (const c of counts) {
-      if (c.trackId) likeCounts[String(c.trackId)] = c._count.trackId;
-    }
-  }
+  const likeCounts = await getAdjustedTrackLikeCounts(trackIds);
 
   // Session likeMap
   const sessionId = await getSessionId();
-  let likeMap: Record<string, string> = {};
+  const likeMap: Record<string, string> = {};
   if (sessionId && trackIds.length > 0) {
     const likes = await prisma.like.findMany({
       where: { sessionId, trackId: { in: trackIds } },

--- a/src/app/[bar]/artists/[id]/records/page.tsx
+++ b/src/app/[bar]/artists/[id]/records/page.tsx
@@ -4,6 +4,7 @@ import { BAR_VALUES, serializeBigInt } from "@/lib/utils";
 
 import { RecordList } from "@/components/RecordList";
 import { getSessionId } from "@/lib/session";
+import { getAdjustedRecordLikeCounts } from "@/lib/ranking-adjustments";
 
 export default async function ArtistRecordsPage({
   params,
@@ -43,21 +44,11 @@ export default async function ArtistRecordsPage({
   const recordIds = records.map((r) => BigInt(r.id));
 
   // Like counts
-  const likeCounts: Record<string, number> = {};
-  if (recordIds.length > 0) {
-    const counts = await prisma.like.groupBy({
-      by: ["recordId"],
-      where: { recordId: { in: recordIds } },
-      _count: { recordId: true },
-    });
-    for (const c of counts) {
-      if (c.recordId) likeCounts[String(c.recordId)] = c._count.recordId;
-    }
-  }
+  const likeCounts = await getAdjustedRecordLikeCounts(recordIds);
 
   // Session likeMap
   const sessionId = await getSessionId();
-  let likeMap: Record<string, string> = {};
+  const likeMap: Record<string, string> = {};
   if (sessionId && recordIds.length > 0) {
     const likes = await prisma.like.findMany({
       where: { sessionId, recordId: { in: recordIds } },

--- a/src/app/[bar]/artists/[id]/tracks/page.tsx
+++ b/src/app/[bar]/artists/[id]/tracks/page.tsx
@@ -3,13 +3,14 @@ import { prisma } from "@/lib/prisma";
 import { serializeBigInt } from "@/lib/utils";
 import { RecordList } from "@/components/RecordList";
 import { getSessionId } from "@/lib/session";
+import { getAdjustedTrackLikeCounts } from "@/lib/ranking-adjustments";
 
 export default async function ArtistTracksPage({
   params,
 }: {
   params: Promise<{ bar: string; id: string }>;
 }) {
-  const { bar, id } = await params;
+  const { id } = await params;
 
   const artist = await prisma.artist.findUnique({
     where: { id: BigInt(id) },
@@ -37,21 +38,11 @@ export default async function ArtistTracksPage({
   const trackIds = tracks.map((t) => BigInt(t.id));
 
   // Like counts
-  const likeCounts: Record<string, number> = {};
-  if (trackIds.length > 0) {
-    const counts = await prisma.like.groupBy({
-      by: ["trackId"],
-      where: { trackId: { in: trackIds } },
-      _count: { trackId: true },
-    });
-    for (const c of counts) {
-      if (c.trackId) likeCounts[String(c.trackId)] = c._count.trackId;
-    }
-  }
+  const likeCounts = await getAdjustedTrackLikeCounts(trackIds);
 
   // Session likeMap
   const sessionId = await getSessionId();
-  let likeMap: Record<string, string> = {};
+  const likeMap: Record<string, string> = {};
   if (sessionId && trackIds.length > 0) {
     const likes = await prisma.like.findMany({
       where: { sessionId, trackId: { in: trackIds } },

--- a/src/app/[bar]/features/[id]/page.tsx
+++ b/src/app/[bar]/features/[id]/page.tsx
@@ -4,6 +4,16 @@ import { prisma } from "@/lib/prisma";
 import { serializeBigInt } from "@/lib/utils";
 import { auth } from "@/lib/auth";
 import { getSessionId } from "@/lib/session";
+import {
+  getAdjustedRecordLikeCounts,
+  getAdjustedTrackLikeCounts,
+} from "@/lib/ranking-adjustments";
+import {
+  assignRecordLikeCounts,
+  assignTrackLikeCounts,
+  recordLikeKey,
+  trackLikeKey,
+} from "@/lib/record-list-keys";
 import { DeleteFeatureButton } from "@/components/admin/DeleteFeatureButton";
 import { RecordList } from "@/components/RecordList";
 import { PageRefresh } from "@/components/PageRefresh";
@@ -60,20 +70,8 @@ export default async function FeatureDetailPage({
             include: { artist: true, album: true },
           })
         : Promise.resolve([]),
-      recordIds.length > 0
-        ? prisma.like.groupBy({
-            by: ["recordId"],
-            where: { recordId: { in: recordIds } },
-            _count: { recordId: true },
-          })
-        : Promise.resolve([]),
-      trackIds.length > 0
-        ? prisma.like.groupBy({
-            by: ["trackId"],
-            where: { trackId: { in: trackIds } },
-            _count: { trackId: true },
-          })
-        : Promise.resolve([]),
+      getAdjustedRecordLikeCounts(recordIds),
+      getAdjustedTrackLikeCounts(trackIds),
       sessionId && allItemIds.length > 0
         ? prisma.like.findMany({
             where: {
@@ -97,18 +95,14 @@ export default async function FeatureDetailPage({
 
   // Build likeCounts
   const likeCounts: Record<string, number> = {};
-  for (const l of recordLikeCounts) {
-    if (l.recordId) likeCounts[String(l.recordId)] = l._count.recordId;
-  }
-  for (const l of trackLikeCounts) {
-    if (l.trackId) likeCounts[String(l.trackId)] = l._count.trackId;
-  }
+  assignRecordLikeCounts(likeCounts, recordLikeCounts);
+  assignTrackLikeCounts(likeCounts, trackLikeCounts);
 
   // Build likeMap
   const likeMap: Record<string, string> = {};
   for (const like of sessionLikes) {
-    const itemId = like.recordId ?? like.trackId;
-    if (itemId) likeMap[String(itemId)] = String(like.id);
+    if (like.recordId) likeMap[recordLikeKey(like.recordId)] = String(like.id);
+    if (like.trackId) likeMap[trackLikeKey(like.trackId)] = String(like.id);
   }
 
   // Build RecordList items

--- a/src/app/[bar]/hi-res/popular/page.tsx
+++ b/src/app/[bar]/hi-res/popular/page.tsx
@@ -3,6 +3,7 @@ import { serializeBigInt } from "@/lib/utils";
 import { RecordList } from "@/components/RecordList";
 import { getSessionId } from "@/lib/session";
 import { NAV, TABLE } from "@/lib/labels";
+import { getTopTrackRanking } from "@/lib/ranking-adjustments";
 
 export const dynamic = "force-dynamic";
 
@@ -24,19 +25,11 @@ export default async function TrackTop100Page({
 }: {
   params: Promise<{ bar: string }>;
 }) {
-  const { bar } = await params;
+  await params;
 
-  const topTrackLikes = await prisma.like.groupBy({
-    by: ["trackId"],
-    where: { trackId: { not: null } },
-    _count: { trackId: true },
-    orderBy: { _count: { trackId: "desc" } },
-    take: 100,
-  });
+  const topTrackRanking = await getTopTrackRanking(100);
 
-  const topTrackIds = topTrackLikes
-    .map((l) => l.trackId)
-    .filter((id): id is bigint => id !== null);
+  const topTrackIds = topTrackRanking.map((row) => row.itemId);
 
   const topTracks =
     topTrackIds.length > 0
@@ -48,13 +41,13 @@ export default async function TrackTop100Page({
 
   // Build likeCounts map
   const likeCounts: Record<string, number> = {};
-  for (const l of topTrackLikes) {
-    if (l.trackId) likeCounts[String(l.trackId)] = l._count.trackId;
+  for (const row of topTrackRanking) {
+    likeCounts[String(row.itemId)] = row.score;
   }
 
   // Build likeMap for current session
   const sessionId = await getSessionId();
-  let likeMap: Record<string, string> = {};
+  const likeMap: Record<string, string> = {};
   if (sessionId && topTrackIds.length > 0) {
     const likes = await prisma.like.findMany({
       where: { sessionId, trackId: { in: topTrackIds } },

--- a/src/app/[bar]/page.tsx
+++ b/src/app/[bar]/page.tsx
@@ -5,6 +5,18 @@ import { BAR_VALUES, serializeBigInt } from "@/lib/utils";
 import { RecordList } from "@/components/RecordList";
 import { RecordCarousel } from "@/components/RecordCarousel";
 import { getSessionId } from "@/lib/session";
+import {
+  getAdjustedRecordLikeCounts,
+  getAdjustedTrackLikeCounts,
+  getTopRecordRanking,
+  getTopTrackRanking,
+} from "@/lib/ranking-adjustments";
+import {
+  assignRecordLikeCounts,
+  assignTrackLikeCounts,
+  recordLikeKey,
+  trackLikeKey,
+} from "@/lib/record-list-keys";
 import { RightUpArrow } from "@/components/icons/RightUpArrow";
 import { AnimatedText } from "@/components/AnimatedText";
 import { FadeIn } from "@/components/FadeIn";
@@ -69,25 +81,10 @@ export default async function BarPage({
   const barValue = BAR_VALUES[bar];
 
   // Parallel: top likes + features + session
-  const [topRecordLikes, topTrackLikes, barFeatures, sessionId] =
+  const [topRecordRanking, topTrackRanking, barFeatures, sessionId] =
     await Promise.all([
-      prisma.like.groupBy({
-        by: ["recordId"],
-        where: {
-          recordId: { not: null },
-          record: { bar: barValue },
-        },
-        _count: { recordId: true },
-        orderBy: { _count: { recordId: "desc" } },
-        take: 20,
-      }),
-      prisma.like.groupBy({
-        by: ["trackId"],
-        where: { trackId: { not: null } },
-        _count: { trackId: true },
-        orderBy: { _count: { trackId: "desc" } },
-        take: 20,
-      }),
+      getTopRecordRanking(barValue, 20),
+      getTopTrackRanking(20),
       prisma.feature.findMany({
         where: { bar: barValue },
         orderBy: { number: "asc" },
@@ -98,12 +95,8 @@ export default async function BarPage({
       getSessionId(),
     ]);
 
-  const topRecordIds = topRecordLikes
-    .map((l) => l.recordId)
-    .filter((id): id is bigint => id !== null);
-  const topTrackIds = topTrackLikes
-    .map((l) => l.trackId)
-    .filter((id): id is bigint => id !== null);
+  const topRecordIds = topRecordRanking.map((row) => row.itemId);
+  const topTrackIds = topTrackRanking.map((row) => row.itemId);
 
   // Collect all feature item IDs for batch query
   const featureRecordIds: bigint[] = [];
@@ -121,7 +114,7 @@ export default async function BarPage({
   const allRecordIds = [...topRecordIds, ...featureRecordIds];
   const allTrackIds = [...topTrackIds, ...featureTrackIds];
 
-  const [topRecords, topTracks, featureRecords, featureTracks, ...likeResults] =
+  const [topRecords, topTracks, featureRecords, featureTracks, recordLikeCounts, trackLikeCounts] =
     await Promise.all([
       topRecordIds.length > 0
         ? prisma.record.findMany({
@@ -147,30 +140,14 @@ export default async function BarPage({
             include: { artist: true, album: true },
           })
         : Promise.resolve([]),
-      allRecordIds.length > 0
-        ? prisma.like.groupBy({
-            by: ["recordId"],
-            where: { recordId: { in: allRecordIds } },
-            _count: { recordId: true },
-          })
-        : Promise.resolve([]),
-      allTrackIds.length > 0
-        ? prisma.like.groupBy({
-            by: ["trackId"],
-            where: { trackId: { in: allTrackIds } },
-            _count: { trackId: true },
-          })
-        : Promise.resolve([]),
+      getAdjustedRecordLikeCounts(allRecordIds),
+      getAdjustedTrackLikeCounts(allTrackIds),
     ]);
 
   // Build likeCounts map
   const likeCounts: Record<string, number> = {};
-  for (const l of likeResults[0] as { recordId: bigint | null; _count: { recordId: number } }[]) {
-    if (l.recordId) likeCounts[String(l.recordId)] = l._count.recordId;
-  }
-  for (const l of likeResults[1] as { trackId: bigint | null; _count: { trackId: number } }[]) {
-    if (l.trackId) likeCounts[String(l.trackId)] = l._count.trackId;
-  }
+  assignRecordLikeCounts(likeCounts, recordLikeCounts);
+  assignTrackLikeCounts(likeCounts, trackLikeCounts);
 
   // Build lookup maps for feature items
   const recordMap = new Map(
@@ -196,7 +173,7 @@ export default async function BarPage({
     return { ...feature, resolvedItems };
   });
 
-  let likeMap: Record<string, string> = {};
+  const likeMap: Record<string, string> = {};
   if (sessionId) {
     const orConditions = [];
     if (allRecordIds.length > 0)
@@ -209,8 +186,8 @@ export default async function BarPage({
         where: { sessionId, OR: orConditions },
       });
       for (const like of likes) {
-        const itemId = like.recordId ?? like.trackId;
-        if (itemId) likeMap[String(itemId)] = String(like.id);
+        if (like.recordId) likeMap[recordLikeKey(like.recordId)] = String(like.id);
+        if (like.trackId) likeMap[trackLikeKey(like.trackId)] = String(like.id);
       }
     }
   }

--- a/src/app/[bar]/records/popular/page.tsx
+++ b/src/app/[bar]/records/popular/page.tsx
@@ -3,6 +3,7 @@ import { BAR_VALUES, serializeBigInt } from "@/lib/utils";
 import { RecordList } from "@/components/RecordList";
 import { getSessionId } from "@/lib/session";
 import { NAV, TABLE } from "@/lib/labels";
+import { getTopRecordRanking } from "@/lib/ranking-adjustments";
 
 export const dynamic = "force-dynamic";
 
@@ -27,20 +28,9 @@ export default async function RecordTop100Page({
   const { bar } = await params;
   const barValue = BAR_VALUES[bar];
 
-  const topRecordLikes = await prisma.like.groupBy({
-    by: ["recordId"],
-    where: {
-      recordId: { not: null },
-      record: { bar: barValue },
-    },
-    _count: { recordId: true },
-    orderBy: { _count: { recordId: "desc" } },
-    take: 100,
-  });
+  const topRecordRanking = await getTopRecordRanking(barValue, 100);
 
-  const topRecordIds = topRecordLikes
-    .map((l) => l.recordId)
-    .filter((id): id is bigint => id !== null);
+  const topRecordIds = topRecordRanking.map((row) => row.itemId);
 
   const topRecords =
     topRecordIds.length > 0
@@ -52,13 +42,13 @@ export default async function RecordTop100Page({
 
   // Build likeCounts map
   const likeCounts: Record<string, number> = {};
-  for (const l of topRecordLikes) {
-    if (l.recordId) likeCounts[String(l.recordId)] = l._count.recordId;
+  for (const row of topRecordRanking) {
+    likeCounts[String(row.itemId)] = row.score;
   }
 
   // Build likeMap for current session
   const sessionId = await getSessionId();
-  let likeMap: Record<string, string> = {};
+  const likeMap: Record<string, string> = {};
   if (sessionId && topRecordIds.length > 0) {
     const likes = await prisma.like.findMany({
       where: { sessionId, recordId: { in: topRecordIds } },

--- a/src/app/api/likes/[id]/route.ts
+++ b/src/app/api/likes/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSessionId } from "@/lib/session";
+import { getAdjustedLikeCount } from "@/lib/ranking-adjustments";
 
 export async function DELETE(
   _request: NextRequest,
@@ -21,6 +22,10 @@ export async function DELETE(
   }
 
   await prisma.like.delete({ where: { id: like.id } });
+  const likeCount = await getAdjustedLikeCount({
+    recordId: like.recordId,
+    trackId: like.trackId,
+  });
 
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, likeCount });
 }

--- a/src/app/api/likes/route.ts
+++ b/src/app/api/likes/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getOrCreateSessionId, getSessionId } from "@/lib/session";
 import { serializeBigInt } from "@/lib/utils";
+import { getAdjustedLikeCount } from "@/lib/ranking-adjustments";
 
 export async function POST(request: NextRequest) {
   const sessionId = await getOrCreateSessionId();
@@ -21,8 +22,9 @@ export async function POST(request: NextRequest) {
     const like = await prisma.like.create({
       data: { sessionId, recordId, trackId },
     });
+    const likeCount = await getAdjustedLikeCount({ recordId, trackId });
 
-    return NextResponse.json(serializeBigInt(like), { status: 201 });
+    return NextResponse.json(serializeBigInt({ ...like, likeCount }), { status: 201 });
   } catch (e: unknown) {
     if (
       typeof e === "object" &&

--- a/src/app/api/ranking-adjustments/route.ts
+++ b/src/app/api/ranking-adjustments/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { serializeBigInt } from "@/lib/utils";
+
+type ItemType = "Record" | "Track" | "Hi-Res";
+
+function isItemType(value: unknown): value is ItemType {
+  return value === "Record" || value === "Track" || value === "Hi-Res";
+}
+
+function isBigIntString(value: unknown): value is string {
+  return typeof value === "string" && /^\d+$/.test(value);
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const itemType = body.itemType;
+  const itemId = body.itemId;
+  const scoreDelta = Number(body.scoreDelta);
+
+  if (!isItemType(itemType) || !isBigIntString(itemId) || !Number.isInteger(scoreDelta)) {
+    return NextResponse.json(
+      { error: "itemType, itemId, and integer scoreDelta are required" },
+      { status: 400 },
+    );
+  }
+
+  const id = BigInt(itemId);
+  const isRecord = itemType === "Record";
+
+  if (scoreDelta === 0) {
+    await prisma.rankingAdjustment.deleteMany({
+      where: isRecord ? { recordId: id } : { trackId: id },
+    });
+    return NextResponse.json({ scoreDelta: 0 });
+  }
+
+  const adjustment = isRecord
+    ? await prisma.rankingAdjustment.upsert({
+        where: { recordId: id },
+        create: { recordId: id, scoreDelta },
+        update: { scoreDelta },
+      })
+    : await prisma.rankingAdjustment.upsert({
+        where: { trackId: id },
+        create: { trackId: id, scoreDelta },
+        update: { scoreDelta },
+      });
+
+  return NextResponse.json(serializeBigInt(adjustment));
+}

--- a/src/app/api/records/[id]/route.ts
+++ b/src/app/api/records/[id]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
   const { id } = await params;
   const record = await prisma.record.findUnique({
     where: { id: BigInt(id) },
-    include: { owner: true, artist: true },
+    include: { owner: true, artist: true, rankingAdjustment: true },
   });
 
   if (!record) {

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { serializeBigInt, BAR_VALUES, buildPrefixFilter } from "@/lib/utils";
+import {
+  getSortedAdminRecordIds,
+  parseAdminListSort,
+} from "@/lib/admin-list-sort";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -8,26 +12,29 @@ export async function GET(request: NextRequest) {
   const hasPrefix = searchParams.get("has_prefix");
   const ownerId = searchParams.get("owner_id");
   const query = searchParams.get("query");
+  const sort = parseAdminListSort(searchParams.get("sort"));
+  const barValue = bar && BAR_VALUES[bar] !== undefined ? BAR_VALUES[bar] : undefined;
+  const parsedOwnerId = ownerId ? BigInt(ownerId) : undefined;
+  const artistId = searchParams.get("artistId");
+  const parsedArtistId = artistId ? BigInt(artistId) : undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const where: any = {};
 
-  if (bar && BAR_VALUES[bar] !== undefined) {
-    where.bar = BAR_VALUES[bar];
+  if (barValue !== undefined) {
+    where.bar = barValue;
   }
 
   if (hasPrefix) {
     Object.assign(where, buildPrefixFilter(hasPrefix));
   }
 
-  const artistId = searchParams.get("artistId");
-
-  if (ownerId) {
-    where.ownerId = BigInt(ownerId);
+  if (parsedOwnerId !== undefined) {
+    where.ownerId = parsedOwnerId;
   }
 
-  if (artistId) {
-    where.artistId = BigInt(artistId);
+  if (parsedArtistId !== undefined) {
+    where.artistId = parsedArtistId;
   }
 
   if (query) {
@@ -44,10 +51,52 @@ export async function GET(request: NextRequest) {
   const limit = parseInt(searchParams.get("limit") ?? "500", 10);
   const skip = (page - 1) * limit;
 
+  if (sort) {
+    const [recordIds, total] = await Promise.all([
+      getSortedAdminRecordIds({
+        barValue,
+        hasPrefix,
+        ownerId: parsedOwnerId,
+        artistId: parsedArtistId,
+        query,
+        sort,
+        take: limit,
+        skip,
+      }),
+      prisma.record.count({ where }),
+    ]);
+
+    const records =
+      recordIds.length === 0
+        ? []
+        : await prisma.record.findMany({
+            where: { id: { in: recordIds } },
+            include: {
+              owner: true,
+              artist: true,
+              rankingAdjustment: true,
+              _count: { select: { likes: true } },
+            },
+          });
+
+    const recordById = new Map(records.map((record) => [record.id.toString(), record]));
+    const sortedRecords = recordIds.flatMap((id) => {
+      const record = recordById.get(id.toString());
+      return record ? [record] : [];
+    });
+
+    return NextResponse.json(serializeBigInt({ data: sortedRecords, total, page, limit }));
+  }
+
   const [records, total] = await Promise.all([
     prisma.record.findMany({
       where,
-      include: { owner: true, artist: true, _count: { select: { likes: true } } },
+      include: {
+        owner: true,
+        artist: true,
+        rankingAdjustment: true,
+        _count: { select: { likes: true } },
+      },
       orderBy: { artist: { name: "asc" } },
       take: limit,
       skip,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -2,6 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { serializeBigInt, BAR_VALUES } from "@/lib/utils";
 import { getSessionId } from "@/lib/session";
+import {
+  getAdjustedRecordLikeCounts,
+  getAdjustedTrackLikeCounts,
+} from "@/lib/ranking-adjustments";
+import {
+  assignRecordLikeCounts,
+  assignTrackLikeCounts,
+  recordLikeKey,
+  trackLikeKey,
+} from "@/lib/record-list-keys";
 
 export async function GET(request: NextRequest) {
   const query = request.nextUrl.searchParams.get("query");
@@ -58,29 +68,13 @@ export async function GET(request: NextRequest) {
   const trackIds = tracks.map((t) => t.id);
 
   // Fetch like counts
+  const [recordLikeCounts, trackLikeCounts] = await Promise.all([
+    getAdjustedRecordLikeCounts(recordIds),
+    getAdjustedTrackLikeCounts(trackIds),
+  ]);
   const likeCounts: Record<string, number> = {};
-
-  if (recordIds.length > 0) {
-    const recordLikes = await prisma.like.groupBy({
-      by: ["recordId"],
-      where: { recordId: { in: recordIds } },
-      _count: { recordId: true },
-    });
-    for (const l of recordLikes) {
-      if (l.recordId) likeCounts[String(l.recordId)] = l._count.recordId;
-    }
-  }
-
-  if (trackIds.length > 0) {
-    const trackLikes = await prisma.like.groupBy({
-      by: ["trackId"],
-      where: { trackId: { in: trackIds } },
-      _count: { trackId: true },
-    });
-    for (const l of trackLikes) {
-      if (l.trackId) likeCounts[String(l.trackId)] = l._count.trackId;
-    }
-  }
+  assignRecordLikeCounts(likeCounts, recordLikeCounts);
+  assignTrackLikeCounts(likeCounts, trackLikeCounts);
 
   // Fetch likeMap for current session
   const sessionId = await getSessionId();
@@ -96,8 +90,8 @@ export async function GET(request: NextRequest) {
         where: { sessionId, OR: orConditions },
       });
       for (const like of likes) {
-        const itemId = like.recordId ?? like.trackId;
-        if (itemId) likeMap[String(itemId)] = String(like.id);
+        if (like.recordId) likeMap[recordLikeKey(like.recordId)] = String(like.id);
+        if (like.trackId) likeMap[trackLikeKey(like.trackId)] = String(like.id);
       }
     }
   }

--- a/src/app/api/tracks/[id]/route.ts
+++ b/src/app/api/tracks/[id]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
   const { id } = await params;
   const track = await prisma.track.findUnique({
     where: { id: BigInt(id) },
-    include: { artist: true, album: true },
+    include: { artist: true, album: true, rankingAdjustment: true },
   });
 
   if (!track) {

--- a/src/app/api/tracks/route.ts
+++ b/src/app/api/tracks/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { serializeBigInt, BAR_VALUES, buildPrefixFilter } from "@/lib/utils";
+import {
+  getSortedAdminTrackIds,
+  parseAdminListSort,
+} from "@/lib/admin-list-sort";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -9,18 +13,22 @@ export async function GET(request: NextRequest) {
   const bar = searchParams.get("bar");
   const artistId = searchParams.get("artistId");
   const albumId = searchParams.get("albumId");
+  const sort = parseAdminListSort(searchParams.get("sort"));
+  const barValue = bar && BAR_VALUES[bar] !== undefined ? BAR_VALUES[bar] : undefined;
+  const parsedArtistId = artistId ? BigInt(artistId) : undefined;
+  const parsedAlbumId = albumId ? BigInt(albumId) : undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const where: any = {};
 
-  if (bar && BAR_VALUES[bar] !== undefined) {
-    where.bar = BAR_VALUES[bar];
+  if (barValue !== undefined) {
+    where.bar = barValue;
   }
-  if (artistId) {
-    where.artistId = BigInt(artistId);
+  if (parsedArtistId !== undefined) {
+    where.artistId = parsedArtistId;
   }
-  if (albumId) {
-    where.albumId = BigInt(albumId);
+  if (parsedAlbumId !== undefined) {
+    where.albumId = parsedAlbumId;
   }
   if (hasPrefix) {
     Object.assign(where, buildPrefixFilter(hasPrefix));
@@ -40,10 +48,52 @@ export async function GET(request: NextRequest) {
   const limit = parseInt(searchParams.get("limit") ?? "500", 10);
   const skip = (page - 1) * limit;
 
+  if (sort) {
+    const [trackIds, total] = await Promise.all([
+      getSortedAdminTrackIds({
+        barValue,
+        hasPrefix,
+        artistId: parsedArtistId,
+        albumId: parsedAlbumId,
+        query,
+        sort,
+        take: limit,
+        skip,
+      }),
+      prisma.track.count({ where }),
+    ]);
+
+    const tracks =
+      trackIds.length === 0
+        ? []
+        : await prisma.track.findMany({
+            where: { id: { in: trackIds } },
+            include: {
+              artist: true,
+              album: true,
+              rankingAdjustment: true,
+              _count: { select: { likes: true } },
+            },
+          });
+
+    const trackById = new Map(tracks.map((track) => [track.id.toString(), track]));
+    const sortedTracks = trackIds.flatMap((id) => {
+      const track = trackById.get(id.toString());
+      return track ? [track] : [];
+    });
+
+    return NextResponse.json(serializeBigInt({ data: sortedTracks, total, page, limit }));
+  }
+
   const [tracks, total] = await Promise.all([
     prisma.track.findMany({
       where,
-      include: { artist: true, album: true, _count: { select: { likes: true } } },
+      include: {
+        artist: true,
+        album: true,
+        rankingAdjustment: true,
+        _count: { select: { likes: true } },
+      },
       orderBy: { name: "asc" },
       take: limit,
       skip,

--- a/src/components/RecordCarousel.tsx
+++ b/src/components/RecordCarousel.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import { RecordPopup, type PopupData } from "@/components/RecordPopup";
+import { recordListItemKey } from "@/lib/record-list-keys";
 
 type RecordItem = {
   id: string;
@@ -35,7 +36,7 @@ export function RecordCarousel({
   singleColumn?: boolean;
   columns?: string[];
 }) {
-  const [popupItemId, setPopupItemId] = useState<string | null>(null);
+  const [popupItemKey, setPopupItemKey] = useState<string | null>(null);
   const [likeMap, setLikeMap] = useState<Record<string, string>>(
     initialLikeMap ?? {},
   );
@@ -51,6 +52,10 @@ export function RecordCarousel({
   const measured = pageWidth > 0;
   const likeable = initialLikeMap !== undefined;
   const pages = chunk(items, 5);
+  const itemKey = (item: RecordItem) => recordListItemKey(item.id, item.type);
+  const getLikeId = (item: RecordItem) => likeMap[itemKey(item)] ?? likeMap[item.id];
+  const getLikeCount = (item: RecordItem) =>
+    likeCounts[itemKey(item)] ?? likeCounts[item.id] ?? 0;
 
   // Measure alignment with max-w-7xl px-4 container
   useEffect(() => {
@@ -92,25 +97,28 @@ export function RecordCarousel({
   };
 
   const toggleLike = useCallback(
-    async (itemId: string, type: "Record" | "Hi-Res") => {
-      const likeId = likeMap[itemId];
+    async (item: RecordItem) => {
+      const key = recordListItemKey(item.id, item.type);
+      const likeId = likeMap[key] ?? likeMap[item.id];
       const isLiked = !!likeId;
+      const previousCount = likeCounts[key] ?? likeCounts[item.id] ?? 0;
 
       if (isLiked) {
         setLikeMap((prev) => {
           const next = { ...prev };
-          delete next[itemId];
+          delete next[key];
+          delete next[item.id];
           return next;
         });
         setLikeCounts((prev) => ({
           ...prev,
-          [itemId]: Math.max((prev[itemId] ?? 0) - 1, 0),
+          [key]: Math.max(previousCount - 1, 0),
         }));
       } else {
-        setLikeMap((prev) => ({ ...prev, [itemId]: "pending" }));
+        setLikeMap((prev) => ({ ...prev, [key]: "pending" }));
         setLikeCounts((prev) => ({
           ...prev,
-          [itemId]: (prev[itemId] ?? 0) + 1,
+          [key]: previousCount + 1,
         }));
       }
 
@@ -118,11 +126,15 @@ export function RecordCarousel({
         if (isLiked) {
           const res = await fetch(`/api/likes/${likeId}`, { method: "DELETE" });
           if (!res.ok) throw new Error("delete failed");
+          const data = await res.json();
+          if (typeof data.likeCount === "number") {
+            setLikeCounts((prev) => ({ ...prev, [key]: data.likeCount }));
+          }
         } else {
           const body =
-            type === "Record"
-              ? { recordId: itemId }
-              : { trackId: itemId };
+            item.type === "Record"
+              ? { recordId: item.id }
+              : { trackId: item.id };
           const res = await fetch("/api/likes", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -130,33 +142,36 @@ export function RecordCarousel({
           });
           if (!res.ok) throw new Error("create failed");
           const data = await res.json();
-          setLikeMap((prev) => ({ ...prev, [itemId]: String(data.id) }));
+          setLikeMap((prev) => ({ ...prev, [key]: String(data.id) }));
+          if (typeof data.likeCount === "number") {
+            setLikeCounts((prev) => ({ ...prev, [key]: data.likeCount }));
+          }
         }
       } catch {
         if (isLiked) {
-          setLikeMap((prev) => ({ ...prev, [itemId]: likeId }));
+          setLikeMap((prev) => ({ ...prev, [key]: likeId }));
           setLikeCounts((prev) => ({
             ...prev,
-            [itemId]: (prev[itemId] ?? 0) + 1,
+            [key]: previousCount,
           }));
         } else {
           setLikeMap((prev) => {
             const next = { ...prev };
-            delete next[itemId];
+            delete next[key];
             return next;
           });
           setLikeCounts((prev) => ({
             ...prev,
-            [itemId]: Math.max((prev[itemId] ?? 0) - 1, 0),
+            [key]: previousCount,
           }));
         }
       }
     },
-    [likeMap],
+    [likeCounts, likeMap],
   );
 
-  const popupItem = popupItemId
-    ? items.find((i) => i.id === popupItemId)
+  const popupItem = popupItemKey
+    ? items.find((i) => itemKey(i) === popupItemKey)
     : null;
   const popupData: PopupData | null = popupItem
     ? {
@@ -165,12 +180,12 @@ export function RecordCarousel({
         artistName: popupItem.artistName,
         albumName: popupItem.albumName,
         number: popupItem.number,
-        likeCount: likeCounts[popupItem.id] ?? 0,
+        likeCount: getLikeCount(popupItem),
         type: popupItem.type,
         ownerName: popupItem.ownerName,
         location: popupItem.location,
-        isLiked: likeable ? !!likeMap[popupItem.id] : undefined,
-        likeId: likeMap[popupItem.id],
+        isLiked: likeable ? !!getLikeId(popupItem) : undefined,
+        likeId: getLikeId(popupItem),
       }
     : null;
 
@@ -206,13 +221,14 @@ export function RecordCarousel({
               <span className="w-1/5" />
             </div>
             {page.map((item) => {
-              const count = likeCounts[item.id] ?? 0;
-              const isLiked = !!likeMap[item.id];
+              const key = itemKey(item);
+              const count = getLikeCount(item);
+              const isLiked = !!getLikeId(item);
 
               return (
                 <button
-                  key={item.id}
-                  onClick={() => setPopupItemId(item.id)}
+                  key={key}
+                  onClick={() => setPopupItemKey(key)}
                   className="group flex w-full touch-manipulation items-stretch border-b border-zinc-600 first:border-t md:first:border-t-0 text-left transition-colors hover:bg-zinc-900/50"
                 >
                   <span className={`flex min-w-0 ${singleColumn ? "w-4/5" : "w-4/5 flex-col md:flex-row md:items-stretch"}`}>
@@ -298,10 +314,10 @@ export function RecordCarousel({
       {popupData && (
         <RecordPopup
           data={popupData}
-          onClose={() => setPopupItemId(null)}
+          onClose={() => setPopupItemKey(null)}
           onToggleLike={
             likeable
-              ? () => toggleLike(popupData.id, popupData.type)
+              ? () => toggleLike(popupItem!)
               : undefined
           }
         />

--- a/src/components/RecordList.tsx
+++ b/src/components/RecordList.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { RecordPopup, type PopupData } from "@/components/RecordPopup";
+import { recordListItemKey } from "@/lib/record-list-keys";
 
 
 type RecordItem = {
@@ -26,7 +27,7 @@ export function RecordList({
   likeCounts?: Record<string, number>;
   singleColumn?: boolean;
 }) {
-  const [popupItemId, setPopupItemId] = useState<string | null>(null);
+  const [popupItemKey, setPopupItemKey] = useState<string | null>(null);
   const [likeMap, setLikeMap] = useState<Record<string, string>>(
     initialLikeMap ?? {},
   );
@@ -35,28 +36,35 @@ export function RecordList({
   );
 
   const likeable = initialLikeMap !== undefined;
+  const itemKey = (item: RecordItem) => recordListItemKey(item.id, item.type);
+  const getLikeId = (item: RecordItem) => likeMap[itemKey(item)] ?? likeMap[item.id];
+  const getLikeCount = (item: RecordItem) =>
+    likeCounts[itemKey(item)] ?? likeCounts[item.id] ?? 0;
 
   const toggleLike = useCallback(
-    async (itemId: string, type: "Record" | "Hi-Res") => {
-      const likeId = likeMap[itemId];
+    async (item: RecordItem) => {
+      const key = recordListItemKey(item.id, item.type);
+      const likeId = likeMap[key] ?? likeMap[item.id];
       const isLiked = !!likeId;
+      const previousCount = likeCounts[key] ?? likeCounts[item.id] ?? 0;
 
       // Optimistic update
       if (isLiked) {
         setLikeMap((prev) => {
           const next = { ...prev };
-          delete next[itemId];
+          delete next[key];
+          delete next[item.id];
           return next;
         });
         setLikeCounts((prev) => ({
           ...prev,
-          [itemId]: Math.max((prev[itemId] ?? 0) - 1, 0),
+          [key]: Math.max(previousCount - 1, 0),
         }));
       } else {
-        setLikeMap((prev) => ({ ...prev, [itemId]: "pending" }));
+        setLikeMap((prev) => ({ ...prev, [key]: "pending" }));
         setLikeCounts((prev) => ({
           ...prev,
-          [itemId]: (prev[itemId] ?? 0) + 1,
+          [key]: previousCount + 1,
         }));
       }
 
@@ -64,11 +72,15 @@ export function RecordList({
         if (isLiked) {
           const res = await fetch(`/api/likes/${likeId}`, { method: "DELETE" });
           if (!res.ok) throw new Error("delete failed");
+          const data = await res.json();
+          if (typeof data.likeCount === "number") {
+            setLikeCounts((prev) => ({ ...prev, [key]: data.likeCount }));
+          }
         } else {
           const body =
-            type === "Record"
-              ? { recordId: itemId }
-              : { trackId: itemId };
+            item.type === "Record"
+              ? { recordId: item.id }
+              : { trackId: item.id };
           const res = await fetch("/api/likes", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -76,35 +88,38 @@ export function RecordList({
           });
           if (!res.ok) throw new Error("create failed");
           const data = await res.json();
-          setLikeMap((prev) => ({ ...prev, [itemId]: String(data.id) }));
+          setLikeMap((prev) => ({ ...prev, [key]: String(data.id) }));
+          if (typeof data.likeCount === "number") {
+            setLikeCounts((prev) => ({ ...prev, [key]: data.likeCount }));
+          }
         }
       } catch {
         // Rollback on failure
         if (isLiked) {
-          setLikeMap((prev) => ({ ...prev, [itemId]: likeId }));
+          setLikeMap((prev) => ({ ...prev, [key]: likeId }));
           setLikeCounts((prev) => ({
             ...prev,
-            [itemId]: (prev[itemId] ?? 0) + 1,
+            [key]: previousCount,
           }));
         } else {
           setLikeMap((prev) => {
             const next = { ...prev };
-            delete next[itemId];
+            delete next[key];
             return next;
           });
           setLikeCounts((prev) => ({
             ...prev,
-            [itemId]: Math.max((prev[itemId] ?? 0) - 1, 0),
+            [key]: previousCount,
           }));
         }
       }
     },
-    [likeMap],
+    [likeCounts, likeMap],
   );
 
   // Derive popup data from current state
-  const popupItem = popupItemId
-    ? items.find((i) => i.id === popupItemId)
+  const popupItem = popupItemKey
+    ? items.find((i) => itemKey(i) === popupItemKey)
     : null;
   const popupData: PopupData | null = popupItem
     ? {
@@ -113,25 +128,26 @@ export function RecordList({
         artistName: popupItem.artistName,
         albumName: popupItem.albumName,
         number: popupItem.number,
-        likeCount: likeCounts[popupItem.id] ?? 0,
+        likeCount: getLikeCount(popupItem),
         type: popupItem.type,
         ownerName: popupItem.ownerName,
         location: popupItem.location,
-        isLiked: likeable ? !!likeMap[popupItem.id] : undefined,
-        likeId: likeMap[popupItem.id],
+        isLiked: likeable ? !!getLikeId(popupItem) : undefined,
+        likeId: getLikeId(popupItem),
       }
     : null;
 
   return (
     <>
       {items.map((item) => {
-        const count = likeCounts[item.id] ?? 0;
-        const isLiked = !!likeMap[item.id];
+        const key = itemKey(item);
+        const count = getLikeCount(item);
+        const isLiked = !!getLikeId(item);
 
         return (
           <button
-            key={item.id}
-            onClick={() => setPopupItemId(item.id)}
+            key={key}
+            onClick={() => setPopupItemKey(key)}
             className="group flex w-full touch-manipulation items-stretch border-b border-zinc-600 first:border-t md:first:border-t-0 text-left transition-colors hover:bg-zinc-900/50"
           >
             <span className={`flex min-w-0 flex-1 ${singleColumn ? "" : "flex-col md:flex-row md:items-stretch"}`}>
@@ -200,10 +216,10 @@ export function RecordList({
       {popupData && (
         <RecordPopup
           data={popupData}
-          onClose={() => setPopupItemId(null)}
+          onClose={() => setPopupItemKey(null)}
           onToggleLike={
             likeable
-              ? () => toggleLike(popupData.id, popupData.type)
+              ? () => toggleLike(popupItem!)
               : undefined
           }
         />

--- a/src/components/admin/SortableHeaderButton.tsx
+++ b/src/components/admin/SortableHeaderButton.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+export type AdminTableSort = "default" | "likes_desc" | "adjusted_likes_desc";
+
+export function parseAdminTableSort(value: string | null): AdminTableSort {
+  if (value === "likes_desc" || value === "adjusted_likes_desc") return value;
+  return "default";
+}
+
+function SortIcon({
+  active,
+  direction,
+}: {
+  active: boolean;
+  direction: "asc" | "desc";
+}) {
+  if (direction === "asc") {
+    return (
+      <svg
+        className={`h-3.5 w-3.5 ${active ? "text-blue-400" : "text-zinc-400"}`}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M12 19V5" />
+        <path d="m18 11-6-6-6 6" />
+        <path d="M19 19h-4" />
+        <path d="M19 15h-7" />
+        <path d="M19 11h-3" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      className={`h-3.5 w-3.5 ${active ? "text-blue-400" : "text-zinc-400"}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 5v14" />
+      <path d="m18 13-6 6-6-6" />
+      <path d="M19 5h-4" />
+      <path d="M19 9h-7" />
+      <path d="M19 13h-3" />
+    </svg>
+  );
+}
+
+export function SortableHeaderButton({
+  label,
+  active,
+  direction = "desc",
+  title,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  direction?: "asc" | "desc";
+  title: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center justify-end gap-1 whitespace-nowrap font-medium transition-colors hover:text-white ${
+        active ? "text-white" : "text-zinc-400"
+      }`}
+      title={title}
+      aria-label={title}
+      aria-pressed={active}
+    >
+      <span>{label}</span>
+      <SortIcon active={active} direction={direction} />
+    </button>
+  );
+}

--- a/src/lib/admin-list-sort.ts
+++ b/src/lib/admin-list-sort.ts
@@ -1,0 +1,195 @@
+import { Prisma } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export type AdminListSort = "likes_desc" | "adjusted_likes_desc";
+
+type SortedIdRow = {
+  id: bigint;
+};
+
+export function parseAdminListSort(value: string | null): AdminListSort | null {
+  if (value === "likes_desc" || value === "adjusted_likes_desc") return value;
+  return null;
+}
+
+function searchTerms(query: string | null): string[] {
+  return (query ?? "").split(/\s+/).filter(Boolean);
+}
+
+function whereSql(conditions: Prisma.Sql[]): Prisma.Sql {
+  if (conditions.length === 0) return Prisma.empty;
+  return Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}`;
+}
+
+function recordPrefixCondition(hasPrefix: string | null): Prisma.Sql | null {
+  if (!hasPrefix) return null;
+
+  if (/^[a-zA-Z]$/.test(hasPrefix)) {
+    return Prisma.sql`r.phonetic_name LIKE ${`${hasPrefix.toLowerCase()}%`}`;
+  }
+
+  if (hasPrefix === "#") {
+    return Prisma.sql`r.phonetic_name < 'a' AND r.phonetic_name <> ''`;
+  }
+
+  return Prisma.sql`r.furigana LIKE ${`${hasPrefix}%`}`;
+}
+
+function trackPrefixCondition(hasPrefix: string | null): Prisma.Sql | null {
+  if (!hasPrefix) return null;
+
+  if (/^[a-zA-Z]$/.test(hasPrefix)) {
+    return Prisma.sql`t.phonetic_name LIKE ${`${hasPrefix.toLowerCase()}%`}`;
+  }
+
+  if (hasPrefix === "#") {
+    return Prisma.sql`t.phonetic_name < 'a' AND t.phonetic_name <> ''`;
+  }
+
+  return Prisma.sql`t.furigana LIKE ${`${hasPrefix}%`}`;
+}
+
+function recordConditions(params: {
+  barValue?: number;
+  hasPrefix: string | null;
+  ownerId?: bigint;
+  artistId?: bigint;
+  query: string | null;
+}): Prisma.Sql[] {
+  const conditions: Prisma.Sql[] = [];
+
+  if (params.barValue !== undefined) conditions.push(Prisma.sql`r.bar = ${params.barValue}`);
+  if (params.ownerId !== undefined) conditions.push(Prisma.sql`r.owner_id = ${params.ownerId}`);
+  if (params.artistId !== undefined) conditions.push(Prisma.sql`r.artist_id = ${params.artistId}`);
+
+  const prefixCondition = recordPrefixCondition(params.hasPrefix);
+  if (prefixCondition) conditions.push(prefixCondition);
+
+  for (const term of searchTerms(params.query)) {
+    const pattern = `%${term}%`;
+    conditions.push(Prisma.sql`(r.name ILIKE ${pattern} OR a.name ILIKE ${pattern})`);
+  }
+
+  return conditions;
+}
+
+function trackConditions(params: {
+  barValue?: number;
+  hasPrefix: string | null;
+  artistId?: bigint;
+  albumId?: bigint;
+  query: string | null;
+}): Prisma.Sql[] {
+  const conditions: Prisma.Sql[] = [];
+
+  if (params.barValue !== undefined) conditions.push(Prisma.sql`t.bar = ${params.barValue}`);
+  if (params.artistId !== undefined) conditions.push(Prisma.sql`t.artist_id = ${params.artistId}`);
+  if (params.albumId !== undefined) conditions.push(Prisma.sql`t.album_id = ${params.albumId}`);
+
+  const prefixCondition = trackPrefixCondition(params.hasPrefix);
+  if (prefixCondition) conditions.push(prefixCondition);
+
+  for (const term of searchTerms(params.query)) {
+    const pattern = `%${term}%`;
+    conditions.push(Prisma.sql`(t.name ILIKE ${pattern} OR a.name ILIKE ${pattern})`);
+  }
+
+  return conditions;
+}
+
+export async function getSortedAdminRecordIds(params: {
+  barValue?: number;
+  hasPrefix: string | null;
+  ownerId?: bigint;
+  artistId?: bigint;
+  query: string | null;
+  sort: AdminListSort;
+  take: number;
+  skip: number;
+}): Promise<bigint[]> {
+  const orderBy =
+    params.sort === "adjusted_likes_desc"
+      ? Prisma.sql`
+          GREATEST(COALESCE(l.like_count, 0) + COALESCE(ra.score_delta, 0), 0) DESC,
+          COALESCE(l.like_count, 0) DESC,
+          a.name ASC NULLS LAST,
+          r.name ASC NULLS LAST,
+          r.id ASC
+        `
+      : Prisma.sql`
+          COALESCE(l.like_count, 0) DESC,
+          GREATEST(COALESCE(l.like_count, 0) + COALESCE(ra.score_delta, 0), 0) DESC,
+          a.name ASC NULLS LAST,
+          r.name ASC NULLS LAST,
+          r.id ASC
+        `;
+
+  const rows = await prisma.$queryRaw<SortedIdRow[]>`
+    SELECT r.id
+    FROM records r
+    LEFT JOIN artists a ON a.id = r.artist_id
+    LEFT JOIN (
+      SELECT record_id, count(*)::int AS like_count
+      FROM likes
+      WHERE record_id IS NOT NULL
+      GROUP BY record_id
+    ) l ON l.record_id = r.id
+    LEFT JOIN ranking_adjustments ra ON ra.record_id = r.id
+    ${whereSql(recordConditions(params))}
+    ORDER BY ${orderBy}
+    LIMIT ${params.take}
+    OFFSET ${params.skip}
+  `;
+
+  return rows.map((row) => row.id);
+}
+
+export async function getSortedAdminTrackIds(params: {
+  barValue?: number;
+  hasPrefix: string | null;
+  artistId?: bigint;
+  albumId?: bigint;
+  query: string | null;
+  sort: AdminListSort;
+  take: number;
+  skip: number;
+}): Promise<bigint[]> {
+  const orderBy =
+    params.sort === "adjusted_likes_desc"
+      ? Prisma.sql`
+          GREATEST(COALESCE(l.like_count, 0) + COALESCE(ra.score_delta, 0), 0) DESC,
+          COALESCE(l.like_count, 0) DESC,
+          a.name ASC NULLS LAST,
+          al.name ASC NULLS LAST,
+          t.name ASC NULLS LAST,
+          t.id ASC
+        `
+      : Prisma.sql`
+          COALESCE(l.like_count, 0) DESC,
+          GREATEST(COALESCE(l.like_count, 0) + COALESCE(ra.score_delta, 0), 0) DESC,
+          a.name ASC NULLS LAST,
+          al.name ASC NULLS LAST,
+          t.name ASC NULLS LAST,
+          t.id ASC
+        `;
+
+  const rows = await prisma.$queryRaw<SortedIdRow[]>`
+    SELECT t.id
+    FROM tracks t
+    LEFT JOIN artists a ON a.id = t.artist_id
+    LEFT JOIN albums al ON al.id = t.album_id
+    LEFT JOIN (
+      SELECT track_id, count(*)::int AS like_count
+      FROM likes
+      WHERE track_id IS NOT NULL
+      GROUP BY track_id
+    ) l ON l.track_id = t.id
+    LEFT JOIN ranking_adjustments ra ON ra.track_id = t.id
+    ${whereSql(trackConditions(params))}
+    ORDER BY ${orderBy}
+    LIMIT ${params.take}
+    OFFSET ${params.skip}
+  `;
+
+  return rows.map((row) => row.id);
+}

--- a/src/lib/ranking-adjustments.ts
+++ b/src/lib/ranking-adjustments.ts
@@ -1,0 +1,183 @@
+import { prisma } from "@/lib/prisma";
+
+export type RankingResult = {
+  itemId: bigint;
+  likeCount: number;
+  scoreDelta: number;
+  score: number;
+};
+
+type RankingRow = {
+  itemId: bigint;
+  likeCount: number | bigint;
+  scoreDelta: number | bigint;
+  score: number | bigint;
+};
+
+function toNumber(value: number | bigint | null | undefined): number {
+  if (typeof value === "bigint") return Number(value);
+  return value ?? 0;
+}
+
+function normalizeRows(rows: RankingRow[]): RankingResult[] {
+  return rows.map((row) => ({
+    itemId: row.itemId,
+    likeCount: toNumber(row.likeCount),
+    scoreDelta: toNumber(row.scoreDelta),
+    score: toNumber(row.score),
+  }));
+}
+
+function uniqueBigInts(ids: bigint[]): bigint[] {
+  return Array.from(new Map(ids.map((id) => [id.toString(), id])).values());
+}
+
+export function applyScoreDelta(likeCount: number, scoreDelta: number): number {
+  return Math.max(likeCount + scoreDelta, 0);
+}
+
+export async function getTopRecordRanking(
+  barValue: number,
+  take: number,
+): Promise<RankingResult[]> {
+  const rows = await prisma.$queryRaw<RankingRow[]>`
+    SELECT
+      r.id AS "itemId",
+      COALESCE(l.like_count, 0)::int AS "likeCount",
+      COALESCE(ra.score_delta, 0)::int AS "scoreDelta",
+      GREATEST(COALESCE(l.like_count, 0) + COALESCE(ra.score_delta, 0), 0)::int AS "score"
+    FROM records r
+    LEFT JOIN (
+      SELECT record_id, count(*)::int AS like_count
+      FROM likes
+      WHERE record_id IS NOT NULL
+      GROUP BY record_id
+    ) l ON l.record_id = r.id
+    LEFT JOIN ranking_adjustments ra ON ra.record_id = r.id
+    WHERE r.bar = ${barValue}
+      AND GREATEST(COALESCE(l.like_count, 0) + COALESCE(ra.score_delta, 0), 0) > 0
+    ORDER BY "score" DESC, "likeCount" DESC, r.id ASC
+    LIMIT ${take}
+  `;
+
+  return normalizeRows(rows);
+}
+
+export async function getTopTrackRanking(take: number): Promise<RankingResult[]> {
+  const rows = await prisma.$queryRaw<RankingRow[]>`
+    SELECT
+      t.id AS "itemId",
+      COALESCE(l.like_count, 0)::int AS "likeCount",
+      COALESCE(ra.score_delta, 0)::int AS "scoreDelta",
+      GREATEST(COALESCE(l.like_count, 0) + COALESCE(ra.score_delta, 0), 0)::int AS "score"
+    FROM tracks t
+    LEFT JOIN (
+      SELECT track_id, count(*)::int AS like_count
+      FROM likes
+      WHERE track_id IS NOT NULL
+      GROUP BY track_id
+    ) l ON l.track_id = t.id
+    LEFT JOIN ranking_adjustments ra ON ra.track_id = t.id
+    WHERE GREATEST(COALESCE(l.like_count, 0) + COALESCE(ra.score_delta, 0), 0) > 0
+    ORDER BY "score" DESC, "likeCount" DESC, t.id ASC
+    LIMIT ${take}
+  `;
+
+  return normalizeRows(rows);
+}
+
+export async function getAdjustedRecordLikeCounts(
+  recordIds: bigint[],
+): Promise<Record<string, number>> {
+  const ids = uniqueBigInts(recordIds);
+  if (ids.length === 0) return {};
+
+  const [likeCounts, adjustments] = await Promise.all([
+    prisma.like.groupBy({
+      by: ["recordId"],
+      where: { recordId: { in: ids } },
+      _count: { recordId: true },
+    }),
+    prisma.rankingAdjustment.findMany({
+      where: { recordId: { in: ids } },
+      select: { recordId: true, scoreDelta: true },
+    }),
+  ]);
+
+  const rawCounts = new Map<string, number>();
+  for (const count of likeCounts) {
+    if (count.recordId) rawCounts.set(String(count.recordId), count._count.recordId);
+  }
+
+  const scoreDeltas = new Map<string, number>();
+  for (const adjustment of adjustments) {
+    if (adjustment.recordId) {
+      scoreDeltas.set(String(adjustment.recordId), adjustment.scoreDelta);
+    }
+  }
+
+  const counts: Record<string, number> = {};
+  for (const id of ids) {
+    const key = String(id);
+    counts[key] = applyScoreDelta(rawCounts.get(key) ?? 0, scoreDeltas.get(key) ?? 0);
+  }
+  return counts;
+}
+
+export async function getAdjustedLikeCount({
+  recordId,
+  trackId,
+}: {
+  recordId?: bigint | null;
+  trackId?: bigint | null;
+}): Promise<number> {
+  if (recordId) {
+    const counts = await getAdjustedRecordLikeCounts([recordId]);
+    return counts[String(recordId)] ?? 0;
+  }
+
+  if (trackId) {
+    const counts = await getAdjustedTrackLikeCounts([trackId]);
+    return counts[String(trackId)] ?? 0;
+  }
+
+  return 0;
+}
+
+export async function getAdjustedTrackLikeCounts(
+  trackIds: bigint[],
+): Promise<Record<string, number>> {
+  const ids = uniqueBigInts(trackIds);
+  if (ids.length === 0) return {};
+
+  const [likeCounts, adjustments] = await Promise.all([
+    prisma.like.groupBy({
+      by: ["trackId"],
+      where: { trackId: { in: ids } },
+      _count: { trackId: true },
+    }),
+    prisma.rankingAdjustment.findMany({
+      where: { trackId: { in: ids } },
+      select: { trackId: true, scoreDelta: true },
+    }),
+  ]);
+
+  const rawCounts = new Map<string, number>();
+  for (const count of likeCounts) {
+    if (count.trackId) rawCounts.set(String(count.trackId), count._count.trackId);
+  }
+
+  const scoreDeltas = new Map<string, number>();
+  for (const adjustment of adjustments) {
+    if (adjustment.trackId) {
+      scoreDeltas.set(String(adjustment.trackId), adjustment.scoreDelta);
+    }
+  }
+
+  const counts: Record<string, number> = {};
+  for (const id of ids) {
+    const key = String(id);
+    counts[key] = applyScoreDelta(rawCounts.get(key) ?? 0, scoreDeltas.get(key) ?? 0);
+  }
+  return counts;
+}

--- a/src/lib/record-list-keys.ts
+++ b/src/lib/record-list-keys.ts
@@ -1,0 +1,31 @@
+export type RecordListItemType = "Record" | "Hi-Res";
+
+export function recordListItemKey(id: string | number | bigint, type: RecordListItemType): string {
+  return `${type}:${String(id)}`;
+}
+
+export function recordLikeKey(id: string | number | bigint): string {
+  return recordListItemKey(id, "Record");
+}
+
+export function trackLikeKey(id: string | number | bigint): string {
+  return recordListItemKey(id, "Hi-Res");
+}
+
+export function assignRecordLikeCounts(
+  target: Record<string, number>,
+  counts: Record<string, number>,
+) {
+  for (const [id, count] of Object.entries(counts)) {
+    target[recordLikeKey(id)] = count;
+  }
+}
+
+export function assignTrackLikeCounts(
+  target: Record<string, number>,
+  counts: Record<string, number>,
+) {
+  for (const [id, count] of Object.entries(counts)) {
+    target[trackLikeKey(id)] = count;
+  }
+}


### PR DESCRIPTION
## Summary

- Add ranking adjustment storage and APIs so admins can apply positive or negative score corrections without creating dummy likes.
- Apply adjusted like counts to record/Hi-Res rankings, search results, feature pages, artist pages, and album track lists.
- Add admin edit fields for ranking adjustments and show actual likes plus adjustment values on record/track admin lists.
- Add URL-backed sort icons on record/track admin list headers for raw like-count descending and adjusted-score descending order.
- Scope mixed record/Hi-Res list like keys by item type so identical numeric IDs do not overwrite counts or liked state.
- Return recomputed adjusted like counts after like create/delete so optimistic UI is corrected for negative adjustments and clamping.
- Include the pending RLS migration that was already on the local branch, guard Supabase API role revokes when those roles are absent, and add a follow-up migration to lock the new `ranking_adjustments` table from Supabase API roles.

## Validation

- `npx prisma generate`
- `npx prisma validate`
- `npx prisma migrate status`
- `npx tsc --noEmit`
- `npx eslint src/components/admin/SortableHeaderButton.tsx 'src/app/[bar]/admin/records/page.tsx' 'src/app/[bar]/admin/tracks/page.tsx'`
- `npx eslint src/lib/ranking-adjustments.ts src/app/api/likes/route.ts 'src/app/api/likes/[id]/route.ts' src/components/RecordList.tsx src/components/RecordCarousel.tsx`
- `npx eslint src/lib/record-list-keys.ts src/components/RecordList.tsx src/components/RecordCarousel.tsx src/app/api/search/route.ts 'src/app/[bar]/page.tsx' 'src/app/[bar]/features/[id]/page.tsx'`
- `npx eslint src/lib/admin-list-sort.ts src/components/admin/SortableHeaderButton.tsx 'src/app/[bar]/admin/records/page.tsx' 'src/app/[bar]/admin/tracks/page.tsx' src/app/api/records/route.ts src/app/api/tracks/route.ts`
- Read-only DB smoke checks for `likes_desc` / `adjusted_likes_desc` on records and tracks, including search/prefix conditions.
- Full `npm run lint` still has pre-existing unrelated React Hooks errors outside this change.

## Notes

- The ranking adjustment migration was applied before source deployment with `npx prisma migrate deploy`; the RLS lock migration is added separately so already-applied databases can receive the fix cleanly.
- Supabase API role revokes are guarded with `pg_roles` checks, so non-Supabase PostgreSQL databases do not need cluster-level role creation privileges.
- Local reset leftovers such as docs assets and `.gitignore` edits were not included in this PR.